### PR TITLE
Bump dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "url": "https://github.com/trodrigues/concatenify/issues"
   },
   "dependencies": {
-    "through": "~2.3.4",
-    "glob": "~3.2.8",
-    "falafel": "~0.3.1"
+    "through": "~2.3.8",
+    "glob": "~5.0.13",
+    "falafel": "~1.1.0"
   },
   "devDependencies": {
-    "tap": "~0.4.8",
-    "browserify": "~3.30.2"
+    "tap": "~1.3.1",
+    "browserify": "~10.2.4"
   }
 }


### PR DESCRIPTION
All tests are passing, and it would be great if this could be merged. I was encountering errors with `falafel` in particular, since it [updated some things](https://github.com/substack/node-falafel/issues/28) to allow `npm shrinkwrap` to work.
